### PR TITLE
Move EVM's proxy API function pointers into BPL mpool

### DIFF
--- a/fsw/src/bp_app.c
+++ b/fsw/src/bp_app.c
@@ -39,6 +39,7 @@
 #include "bp_dispatch.h"
 #include "bp_cla_bundle_io.h"
 #include "bplib_routing.h"
+#include "bplib_api_types.h"
 #include "bpl_evm_api.h"
 #include "bpnode_evp_cfs.h"
 
@@ -72,8 +73,10 @@ static CFE_Status_t BP_SetupLibrary(void)
         .SendEvent_Impl = BPNODE_EVP_SendEvent_Impl,
     };
 
+
+    bplib_mpool_t * mpool = bplib_route_get_mpool(BP_GlobalData.RouteTbl);
     BPL_Status_t BPL_EVM_Status;
-    BPL_EVM_Status = BPL_EVM_Initialize(EventProxyCallbacks);
+    BPL_EVM_Status = BPL_EVM_Initialize(mpool, EventProxyCallbacks);
     if (BPL_EVM_Status.ReturnValue != BPL_STATUS_SUCCESS)
     {
         fprintf(stderr, "%s(): BPL_EVM_Initialize failed\n", __func__);
@@ -164,7 +167,9 @@ static CFE_Status_t AppInit(void)
     BP_DoRebuildFlowBitmask();
 
     /* Application startup event message */
-    (void) BPL_EVM_SendEvent(BP_INIT_INF_EID, CFE_EVS_EventType_INFORMATION, "BP App Version %d.%d.%d.%d: Initialized",
+    bplib_mpool_t * mpool = bplib_route_get_mpool(BP_GlobalData.RouteTbl);
+    (void) BPL_EVM_SendEvent(mpool, BP_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
+                             "BP App Version %d.%d.%d.%d: Initialized",
                       BP_MAJOR_VERSION, BP_MINOR_VERSION, BP_REVISION, BP_MISSION_REV);
 
     return CFE_SUCCESS;
@@ -212,7 +217,8 @@ void BP_AppMain(void)
     }
 
     /* Exit Application */
-    BPL_EVM_Deinitialize();
+    bplib_mpool_t * mpool = bplib_route_get_mpool(BP_GlobalData.RouteTbl);
+    BPL_EVM_Deinitialize(mpool);
     CFE_EVS_SendEvent(BP_EXIT_ERR_EID, CFE_EVS_EventType_ERROR, "BP application terminating: result = 0x%08X",
                       (unsigned int)run_status);
     CFE_ES_WriteToSysLog("BP application terminating: result = 0x%08X\n",

--- a/fsw/src/bp_app.c
+++ b/fsw/src/bp_app.c
@@ -167,10 +167,18 @@ static CFE_Status_t AppInit(void)
     BP_DoRebuildFlowBitmask();
 
     /* Application startup event message */
+    BPL_Status_t BPL_EVM_Status;
     bplib_mpool_t * mpool = bplib_route_get_mpool(BP_GlobalData.RouteTbl);
-    (void) BPL_EVM_SendEvent(mpool, BP_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
+    BPL_EVM_Status = BPL_EVM_SendEvent(mpool, BP_INIT_INF_EID, CFE_EVS_EventType_INFORMATION,
                              "BP App Version %d.%d.%d.%d: Initialized",
                       BP_MAJOR_VERSION, BP_MINOR_VERSION, BP_REVISION, BP_MISSION_REV);
+    if (BPL_EVM_Status.ReturnValue != BPL_STATUS_SUCCESS)
+    {
+        fprintf(stderr, "BP %s(): BPL_EVM_SendEvent failed with retval %d\n",
+            __func__,
+            BPL_EVM_Status.ReturnValue);
+        return CFE_STATUS_EXTERNAL_RESOURCE_FAIL;
+    }
 
     return CFE_SUCCESS;
 }

--- a/fsw/src/bp_app.c
+++ b/fsw/src/bp_app.c
@@ -76,7 +76,7 @@ static CFE_Status_t BP_SetupLibrary(void)
 
     bplib_mpool_t * mpool = bplib_route_get_mpool(BP_GlobalData.RouteTbl);
     BPL_Status_t BPL_EVM_Status;
-    BPL_EVM_Status = BPL_EVM_Initialize(mpool, EventProxyCallbacks);
+    BPL_EVM_Status = BPL_EVM_Initialize(mpool, &EventProxyCallbacks);
     if (BPL_EVM_Status.ReturnValue != BPL_STATUS_SUCCESS)
     {
         fprintf(stderr, "%s(): BPL_EVM_Initialize failed\n", __func__);


### PR DESCRIPTION
**Describe the contribution**

This PR moves the EVM's proxy API function pointers into the existing mpool struct (in BPL).

The related PR for BPLib is here: https://github.com/keegan-moore/bplib/pull/2

This work is based off of another feature, related to these two PRs:

1. https://github.com/keegan-moore/bplib/pull/1
2. https://github.com/keegan-moore/bp/pull/1

**Testing performed**
Steps taken to test the contribution:
1. Build steps '...'
1. Execution steps '...'

**Expected behavior changes**
A clear and concise description of how this contribution will change behavior and level of impact.
 - API Change: xxx (if applicable)
 - Behavior Change: xxx (if applicable)
 - Or no impact to behavior

**System(s) tested on**
 - Hardware: [e.g. PC, SP0, MCP750]
 - OS: [e.g. Ubuntu 18.04, RTEMS 4.11, VxWorks 6.9]
 - Versions: [e.g. cFE 6.6, OSAL 4.2, PSP 1.3 for mcp750, any related apps or tools]

**Additional context**
Add any other context about the contribution here.

**Third party code**
If included, identify any third party code and provide text file of license

**Contributor Info - All information REQUIRED for consideration of pull request**
Full name and company/organization/center of all contributors ("Personal" if individual work)
- If NASA Civil Servant Employee or GSFC Contractor on SES II
  - Address/email/phone and contract/task information (if applicable) must be on file
- Else if Company
  - **HAND SIGNED** Company CLA must be on file (once per release): [Company CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Corp_CLA_form_1219.pdf)
- Else if Individual
  - **HAND SIGNED** Individual CLA must be on file (once per release): [Individual CLA](https://github.com/nasa/cFE/blob/master/docs/GSC_18128_Ind_CLA_form_1219.pdf)
